### PR TITLE
Add an implementation guidance section

### DIFF
--- a/svgsinrfcs.md
+++ b/svgsinrfcs.md
@@ -67,7 +67,8 @@ The RFC Publication Center (RPC) is responsible for making SVG tooling and imple
 
 # Policy Requirements
 
-* SVG tooling and implementation decisions are made or overseen by the RPC, and must adhere to the policy requirements in this document. The RPC is expected to solicit community input before making these decisions and to publicly explain their reasoning. Documentation for SVG usage in RFCs will be publicly available.
+SVG tooling and implementation decisions are made or overseen by the RPC, and must adhere to the policy requirements in this document. 
+
 * SVGs may be included in RFCs to help explain a concept more clearly, but cannot be the only representation of that concept and must not contain details relevant to the RFC that are not also represented in the text. Normative descriptions of protocols, systems, etc. must be fully represented in the text of the RFC, and must not be contingent on comprehension of any SVG. SVGs are never to be considered as specifications in themselves.
 * SVGs in RFCs must render well on a wide variety of common devices, including those with smaller screens.   
 * SVGs must remain static after publication of the RFC, so there may be interactive, multimedia, or other elements that cannot be used.  
@@ -76,7 +77,23 @@ The RFC Publication Center (RPC) is responsible for making SVG tooling and imple
 * If an SVG is included in an RFC, it should also be included in any publication format that can adequately represent the SVG. The RPC may choose to support conversions from SVG to another image format if a publication format requires it.
 * SVGs should be as accessible as possible to people with visual disabilities, including those who have color blindness, those who need to scale or change fonts, and those who use screen reading software. The RPC will refer to the W3C Accessibility Guidelines {{WAI}} when making decisions regarding accessibility.
 * SVG vocabulary and implementation may change over time and is not required to remain backwards-compatible.
-* The RPC's implementation should strive to allow SVGs produced by widely used drawing tools. Where possible, implementation decisions should focus on specifying what is disallowed, rather than attempting to specify exactly what is allowed.
+
+The RPC is authorized to place constraints on SVG usage in RFCs for both technical and editorial reasons
+in order to ensure that published RFCs meet the above policy
+and to provide consistency across the RFC series.
+The RPC must document the acceptable usage of SVGs in RFCs.
+
+# Implementation Guidance
+
+The RPC is expected to solicit community input before making decisions and to publicly explain their reasoning.
+
+Documentation produced by the RPC should describe what technical and editorial constraints apply to SVGs
+and provide RFC authors with guidance on how to produce diagrams that meet these constraints.
+
+The RPC's implementation should strive to allow SVGs produced by widely used drawing tools.
+Where possible, implementation decisions should focus on specifying what is disallowed, rather than attempting to specify exactly what is allowed.
+
+The RPC should periodically review and revise their practices.
 
 # Security Considerations
 


### PR DESCRIPTION
The policy requirements are a flat list, this changes that to include some framing text, including a stronger statement about who establishes policy.

I took the first item in the list and moved it into top-level text.  This is because it is a higher level point.  Firstly, it empowers the RPC with implementation authority under this policy.  Specifically, it authorizes the RPC to set constraints on what SVGs are (and are not) acceptable.  Secondly, it binds the RPC to document its decisions.

I've split out some of what is suggestions into an implementation guidance section.  The last point was more guidance than policy.  (More on this in a follow-up issue.)

I've tried to avoid altering the substance significantly, but that's unavoidable.  New additions:

* This attempts to explain what the RPC is specifically empowered to do, which is to set some technical and editorial constraints on the use of SVG.  Examples of technical constraints might be a prohibition on scripts.  An editorial constraint might be the choice not to allow paths to form text (as opposed to just having text directly in the image).
* This explains that the point of documentation is twofold.  Firstly, to document the technical and editorial constraints that need to be met.  Secondly, to guide RFC authors toward both compliance with constraints and toward practices that produce better results.
* A suggestion to periodically review the status of policies.

I'll take these to the list, but I thought that I'd share them here as a cover letter.